### PR TITLE
Added timeout to delete query operation

### DIFF
--- a/scripts/Import-BloodHoundCECustomQueries.ps1
+++ b/scripts/Import-BloodHoundCECustomQueries.ps1
@@ -13,7 +13,7 @@ $query = ""
 $counter = 1000
 
 Write-Host "[*] Removing all queries starting with [C-..." -ForegroundColor green
-Get-BHQuery -Name "[C-*" | Remove-BHQuery -Force
+Get-BHQuery -Name "[C-*" | ForEach-Object { Start-Sleep -Milliseconds 100; $_ } | Remove-BHQuery -Force
 Write-Host
 
 Write-Host "[*] Importing queries ..." -ForegroundColor green


### PR DESCRIPTION
To prevent "429 (Too Many Requests)" from occurring during deletion of the queries I added the timeout there as well.